### PR TITLE
Clean code

### DIFF
--- a/expiration.go
+++ b/expiration.go
@@ -2,14 +2,25 @@ package main
 
 import (
 	"crypto/tls"
+	"fmt"
 	"time"
 )
 
-func getExpirationDate(url string, port string) (string, error) {
-	conn, err := tls.Dial("tcp", url+":"+port, nil)
+func buildURL(url, port string) string {
+	return fmt.Sprintf("%s:%s", url, port)
+}
+
+func getExpiryFromConnection(connection *tls.Conn) time.Time {
+	return connection.ConnectionState().PeerCertificates[0].NotAfter
+}
+
+func getExpirationDate(url, port string) (string, error) {
+	connection, err := tls.Dial("tcp", buildURL(url, port), nil)
 	if err != nil {
-		panic("SSL certificate err: " + err.Error())
+		return "", err
 	}
-	expiry := conn.ConnectionState().PeerCertificates[0].NotAfter
-	return expiry.Format(time.RFC3339), err
+
+	expiry := getExpiryFromConnection(connection)
+
+	return expiry.Format(time.RFC3339), nil
 }

--- a/expiration_test.go
+++ b/expiration_test.go
@@ -6,11 +6,12 @@ import (
 )
 
 func TestGetExpirationDate(t *testing.T) {
-	var url string = "www.google.com.ar"
-	var port string = "443"
+	const url = "www.google.com.ar"
+	const port = "443"
+
 	want := regexp.MustCompile(`^((?:(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}(?:\.\d+)?))(Z|[\+-]\d{2}:\d{2})?)$`)
-	expiration_date, err := getExpirationDate(url, port)
-	if !want.MatchString(expiration_date) || err != nil {
-		t.Fatalf(`getExpirationDate(url, port) = %q, %v, want match for %#q, nil`, expiration_date, err, want)
+	expirationDate, err := getExpirationDate(url, port)
+	if !want.MatchString(expirationDate) || err != nil {
+		t.Fatalf(`getExpirationDate(url, port) = %q, %v, want match for %#q, nil`, expirationDate, err, want)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -5,13 +5,16 @@ import (
 	"os"
 )
 
+const url = "www.google.com.ar"
+const port = "443"
+
 func main() {
-	var url string = "www.google.com.ar"
-	var port string = "443"
-	expiration_date, err := getExpirationDate(url, port)
+	expirationDate, err := getExpirationDate(url, port)
+
 	if err != nil {
-		fmt.Println("Problem with ssl certificate")
+		fmt.Println(fmt.Sprintf("Problem with ssl certificate - err: %v", err))
 		os.Exit(1)
 	}
-	fmt.Println(expiration_date)
+
+	fmt.Println(expirationDate)
 }


### PR DESCRIPTION
Following Golang philosophy we should avoid whenever we can to use "panic". Instead is better if you return an error and handle that error in function calls.